### PR TITLE
tweak dev container

### DIFF
--- a/tutorial/getting-started/.devcontainer/devcontainer.json
+++ b/tutorial/getting-started/.devcontainer/devcontainer.json
@@ -12,7 +12,6 @@
 	"features": {
 	  "ghcr.io/devcontainers/features/docker-in-docker:2": {},
 	  "ghcr.io/devcontainers/features/azure-cli:1": {},
-	  "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
 	  "ghcr.io/rio/features/k3d:1": {}
 	},
 	// Configure tool-specific properties.

--- a/tutorial/getting-started/.devcontainer/on-create.sh
+++ b/tutorial/getting-started/.devcontainer/on-create.sh
@@ -13,8 +13,5 @@ sudo apt-get install -y kubectl
 ## Install PostgreSQL CLI
 sudo apt-get install --no-install-recommends --assume-yes postgresql-client
 
-# Install k3d
-curl -fsSL https://raw.githubusercontent.com/rancher/k3d/main/install.sh | /bin/bash 
-
 ## Install Drasi CLI
 curl -fsSL https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh | /bin/bash 

--- a/tutorial/getting-started/.devcontainer/on-create.sh
+++ b/tutorial/getting-started/.devcontainer/on-create.sh
@@ -1,4 +1,20 @@
 #!/bin/sh
 
+# Install kubectl
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg # allow unprivileged APT programs to read this keyring
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list   # helps tools such as command-not-found to work correctly
+sudo apt-get update
+sudo apt-get install -y kubectl
+
+## Install PostgreSQL CLI
+sudo apt-get install --no-install-recommends --assume-yes postgresql-client
+
+# Install k3d
+curl -fsSL https://raw.githubusercontent.com/rancher/k3d/main/install.sh | /bin/bash 
+
 ## Install Drasi CLI
 curl -fsSL https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh | /bin/bash 

--- a/tutorial/getting-started/.devcontainer/post-create.sh
+++ b/tutorial/getting-started/.devcontainer/post-create.sh
@@ -12,11 +12,7 @@ done
 ## Install Drasi
 drasi init
 
-## Install PostgreSQL CLI
-sudo apt-get update
-sudo apt-get install --no-install-recommends --assume-yes postgresql-client
-
-## Install PostgreSQL on K3d
-kubectl apply -f https://raw.githubusercontent.com/drasi-project/learning/main/tutorial/getting-started/resources/drasi-postgres.yaml
+## Install PostgreSQL
+kubectl apply -f ./resources/drasi-postgres.yaml
 sleep 15
 kubectl wait --for=condition=ready pod -l app=postgres --timeout=60s


### PR DESCRIPTION
We were using the `kubectl-helm-minikube` feature just to get kubectl.  Installing minikube is long and expensive, so we can just get kubectl directly using the linux package manager.