### PR TITLE
Configure CODEOWNERS to point to the core-engineers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@agentofreality @danielgerlag @ruokun-niu
+* @drasi-project/drasi-core-engineers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @drasi-project/drasi-core-engineers
+* @drasi-project/maintainers-learning


### PR DESCRIPTION
**Note**: This PR is created from a branch instead of a fork as I had to validate the CODEOWNERS.

