### PR TITLE
Support launching Drasi Tutorial in Github Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,52 @@
+{
+  "name": "Getting started with Drasi",
+  "extends": "./base.devcontainer.json",
+  "workspaceFolder": "/workspaces/learning/tutorial/getting-started", 
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "onCreateCommand": "bash ./.devcontainer/on-create.sh",
+  "postCreateCommand": "bash ./.devcontainer/post-create.sh",
+  "postStartCommand": "bash -c 'kubectl port-forward svc/postgres 5432:5432 &'",
+	"runArgs": [
+	  "--privileged",
+	  "--init"
+  ],
+  // Features to add to the dev container. More info: https://containers.dev/features
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/rio/features/k3d:1": {}
+  },
+  // Configure tool-specific properties.
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      "settings": {},
+      "extensions": [
+        "ckolkman.vscode-postgres"
+      ]
+    }
+  },
+  "remoteEnv": {
+    "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
+    "PGHOST": "localhost",
+    "PGDATABASE": "hello-world",
+    "PGPORT": "5432",
+    "PGUSER" : "test",
+    "PGPASSWORD" : "test"
+  },
+  // Use 'portsAttributes' to set default properties for specific forwarded ports.
+  // More info: https://containers.dev/implementors/json_reference/#port-attributes
+  "portsAttributes": {
+    "5432": {
+    "label": "postgres",
+    "onAutoForward": "silent"
+    },
+    "8081": {
+    "label": "k3s",
+    "onAutoForward": "silent"
+    },
+    "9083": {
+    "label": "drasi",
+    "onAutoForward": "silent"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Learning about Drasi
-This repo contains code for sample applications that use Drasi as an end-to-end solution for change detection and real-time reactions. The applications will help you understand how to implement and deploy Drasi for different scenarios. Each app folder  within this repo has a README.md which details what the scenario for the app, code for the apps, requisite test data, and how to run the samples.
+This repo contains code for a tutorial and a few sample applications that use Drasi as an end-to-end solution for change detection and real-time reactions. The tutorial The applications will help you understand how to implement and deploy Drasi for different scenarios. Each app folder within this repo has a README.md which details what the scenario for the app, code for the apps, requisite test data, and how to run the samples.
+
+## Getting Started with Drasi
+#### Detect and react to your first database change using Drasi
+[This step-by-step tutorial](https://drasi.io/getting-started/) will help you get Drasi up and running quickly and show you how easy it is to create Sources, Continuous Queries, and Reactions.
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/drasi-project/learning)
 
 ## Sample Applications
-This repo has the following applications in folders:
+Following sample applications demonstrate usage of Drasi in different scenarios:
 1. [Building comfort](apps/building-comfort)- Drasi for a building management scenario
 2. [Curbside pickup](apps/curbside-pickup)- Drasi for a notification service to alert drivers when orders are ready for pickup
 3. [Fleet POC](https://github.com/drasi-project/learning/tree/main/apps/fleet-poc)- Drasi for an efficient solution to translate vehicle telemetery into actionable insights for Connected Fleet scenarios

--- a/tutorial/getting-started/README.md
+++ b/tutorial/getting-started/README.md
@@ -1,4 +1,7 @@
-To use the Drasi QuickStart Tutorial Dev Container
+# Getting Started with Drasi
+Follow the tutorial [instructions here](https://drasi.io/getting-started/).
+
+### Steps for running in VS Code with a Dev Container
 1. Open this directory in Visual Studio Code
 2. Open the Command Palette by typing `Ctrl + Shift + P` (windows) or `Cmd + Shift + P` (mac)
 3. Type 'dev containers:'


### PR DESCRIPTION
# Description
- Add `.devcontainer/devcontainer.json` file to serve as default codespace configuration. This launches getting started tutorial.
- Update the README.md file for Getting Started tutorial to provide link to Drasi Docs and separate out the VS Code steps.
 