### PR TITLE
Configure locale for building-comfort container image

### DIFF
--- a/.devcontainer/building-comfort/devcontainer.json
+++ b/.devcontainer/building-comfort/devcontainer.json
@@ -36,6 +36,12 @@
 	  // Install Python
 	  "ghcr.io/devcontainers/features/python:1": {}
 	},
+	// Configure environment variables
+    "containerEnv": {
+        "LANG": "en_US.UTF-8",
+        "LANGUAGE": "en_US:en",
+        "LC_ALL": "en_US.UTF-8"
+    },
 	"remoteEnv": {
 	  "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
 	  "PGHOST": "localhost",
@@ -45,8 +51,6 @@
 	  "PGPASSWORD" : "test"
 
 	},
-	// Use 'portsAttributes' to set default properties for specific forwarded ports.
-	// More info: https://containers.dev/implementors/json_reference/#port-attributes
 	"portsAttributes": {
 	  "5432": {
 		"label": "postgres",

--- a/.devcontainer/building-comfort/on-create.sh
+++ b/.devcontainer/building-comfort/on-create.sh
@@ -14,4 +14,10 @@
 # limitations under the License.
 
 ## Install Drasi CLI
-curl -fsSL https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh | /bin/bash 
+curl -fsSL https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh | /bin/bash
+
+## Setting up locale since `node:18-bookworm` does not have it configured
+apt-get update
+apt-get install -y locales
+sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen
+locale-gen


### PR DESCRIPTION
The `node:18-bookworm` image does not have locale setup.
This leads to warning when a user launches `psql` command as part of tutorial.
This change sets up en_US.UTF-8 locale to prevent that.