### PR TITLE
Update tutorial devcontainers to use post-start for port-forwarding

### DIFF
--- a/.devcontainer/building-comfort/devcontainer.json
+++ b/.devcontainer/building-comfort/devcontainer.json
@@ -4,7 +4,7 @@
 	"workspaceFolder": "/workspaces/learning/apps/building-comfort",
 	"onCreateCommand": "sed -i 's/\r$//' ../../.devcontainer/building-comfort/post-create.sh && sed -i  's/\r$//' ../../.devcontainer/building-comfort/on-create.sh && bash ../../.devcontainer/building-comfort/on-create.sh",
 	"postCreateCommand": "bash ../../.devcontainer/building-comfort/post-create.sh",
-    "postStartCommand": "bash ../../.devcontainer/curbside-pickup/post-start.sh",
+    "postStartCommand": "bash ../../.devcontainer/building-comfort/post-start.sh",
 	"runArgs": [
 	  "--privileged",
 	  "--init"

--- a/.devcontainer/building-comfort/devcontainer.json
+++ b/.devcontainer/building-comfort/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"name": "Building Comfort with Drasi",
 	"image": "node:18-bookworm",
-	"workspaceFolder": "/workspaces/learning/apps/building-comfort",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}/apps/building-comfort",
 	"onCreateCommand": "sed -i 's/\r$//' ../../.devcontainer/building-comfort/post-create.sh && sed -i  's/\r$//' ../../.devcontainer/building-comfort/on-create.sh && bash ../../.devcontainer/building-comfort/on-create.sh",
 	"postCreateCommand": "bash ../../.devcontainer/building-comfort/post-create.sh",
     "postStartCommand": "bash ../../.devcontainer/building-comfort/post-start.sh",

--- a/.devcontainer/building-comfort/devcontainer.json
+++ b/.devcontainer/building-comfort/devcontainer.json
@@ -4,7 +4,7 @@
 	"workspaceFolder": "/workspaces/learning/apps/building-comfort",
 	"onCreateCommand": "sed -i 's/\r$//' ../../.devcontainer/building-comfort/post-create.sh && sed -i  's/\r$//' ../../.devcontainer/building-comfort/on-create.sh && bash ../../.devcontainer/building-comfort/on-create.sh",
 	"postCreateCommand": "bash ../../.devcontainer/building-comfort/post-create.sh",
-	"postAttachCommand": "nohup bash -c 'kubectl port-forward svc/postgres 5432:5432 &'",
+    "postStartCommand": "bash ../../.devcontainer/curbside-pickup/post-start.sh",
 	"runArgs": [
 	  "--privileged",
 	  "--init"
@@ -12,7 +12,7 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"ritwickdey.LiveServer",
+				"ritwickdey.LiveServer"
 			]
 		}
 	},

--- a/.devcontainer/building-comfort/post-create.sh
+++ b/.devcontainer/building-comfort/post-create.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-## Create a k3d cluster
+echo "Create a k3d cluster..."
 while ( ! kubectl cluster-info ); do
   # Docker takes a few seconds to initialize
   echo "Waiting for Docker to launch..."
@@ -22,10 +22,10 @@ while ( ! kubectl cluster-info ); do
   sleep 1
 done
 
-## Create Postgres service on k3d cluster and forward its port
+echo "Create Postgres service on k3d cluster..."
 kubectl apply -f ./devops/data/postgres.yaml
 sleep 15
 kubectl wait --for=condition=ready pod -l app=postgres --timeout=60s
 
-## Install Drasi
+echo "Install Drasi..."
 drasi init

--- a/.devcontainer/building-comfort/post-start.sh
+++ b/.devcontainer/building-comfort/post-start.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Copyright 2025 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Function to check if a port is already in use
+check_port() {
+  local port=$1
+  if lsof -i :"$port" > /dev/null 2>&1; then
+    echo "Port $port is already in use. Skipping port-forward."
+    return 1
+  fi
+  return 0
+}
+
+# Set a known log directory
+LOG_DIR="/tmp"
+mkdir -p "$LOG_DIR" || echo "Warning: Could not create $LOG_DIR"
+
+# Clean up any existing port-forward processes
+pkill -f "kubectl port-forward svc/postgres" 2>/dev/null || echo "No prior postgres port-forward process found."
+
+# Verify cluster connectivity
+echo "Checking cluster connectivity..."
+if ! kubectl cluster-info > /dev/null 2>&1; then
+  echo "Error: Cannot connect to the cluster. Check k3d setup."
+  exit 1
+fi
+
+# Verify services exist
+echo "Checking for svc/postgres..."
+kubectl get svc/postgres || echo "Warning: svc/postgres not found."
+
+# Forward PostgreSQL port
+if check_port 5432; then
+  echo "Starting port-forward for PostgreSQL..."
+  nohup kubectl port-forward svc/postgres 5432:5432 > "$LOG_DIR/postgres-port-forward.log" 2>&1 &
+  sleep 1  # Give it a moment to start
+  if ps aux | grep -q "[k]ubectl port-forward svc/postgres"; then
+    echo "PostgreSQL port-forward started (logs at $LOG_DIR/postgres-port-forward.log)."
+  else
+    echo "Error: PostgreSQL port-forward failed to start. Check $LOG_DIR/postgres-port-forward.log."
+  fi
+else
+  echo "PostgreSQL port-forward skipped due to port conflict."
+fi
+
+# Final check
+echo "Running processes:"
+ps aux | grep "[k]ubectl port-forward" || echo "No kubectl port-forward processes found."

--- a/.devcontainer/curbside-pickup/devcontainer.json
+++ b/.devcontainer/curbside-pickup/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"name": "Curbside Pickup with Drasi",
 	"image": "node:18-bookworm",
-	"workspaceFolder": "/workspaces/learning/apps/curbside-pickup",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}/apps/curbside-pickup",
 	"onCreateCommand": "sed -i 's/\r$//' ../../.devcontainer/curbside-pickup/post-create.sh && sed -i  's/\r$//' ../../.devcontainer/curbside-pickup/on-create.sh && sed -i  's/\r$//' ../../.devcontainer/curbside-pickup/post-start.sh && bash ../../.devcontainer/curbside-pickup/on-create.sh",
 	"postCreateCommand": "bash ../../.devcontainer/curbside-pickup/post-create.sh",
     "postStartCommand": "bash ../../.devcontainer/curbside-pickup/post-start.sh",

--- a/.devcontainer/curbside-pickup/post-create.sh
+++ b/.devcontainer/curbside-pickup/post-create.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions andls
 # limitations under the License.
 
-## Create a k3d cluster
+echo "Create a k3d cluster..."
 while ( ! kubectl cluster-info ); do
   # Docker takes a few seconds to initialize
   echo "Waiting for Docker to launch..."

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "image": "mcr.microsoft.com/devcontainers/typescript-node:dev-22",
   "onCreateCommand": "sed -i 's/\r$//' ../../.devcontainer/post-create.sh && sed -i  's/\r$//' ../../.devcontainer/on-create.sh && bash ../../.devcontainer/on-create.sh",
   "postCreateCommand": "bash ../../.devcontainer/post-create.sh",
-  "postStartCommand": "bash ../../.devcontainer/curbside-pickup/post-start.sh",
+  "postStartCommand": "bash ../../.devcontainer/post-start.sh",
 	"runArgs": [
 	  "--privileged",
 	  "--init"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "image": "mcr.microsoft.com/devcontainers/typescript-node:dev-22",
   "onCreateCommand": "sed -i 's/\r$//' ../../.devcontainer/post-create.sh && sed -i  's/\r$//' ../../.devcontainer/on-create.sh && bash ../../.devcontainer/on-create.sh",
   "postCreateCommand": "bash ../../.devcontainer/post-create.sh",
-  "postAttachCommand": "nohup bash -c 'kubectl port-forward svc/postgres 5432:5432 &'",
+  "postStartCommand": "bash ../../.devcontainer/curbside-pickup/post-start.sh",
 	"runArgs": [
 	  "--privileged",
 	  "--init"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Getting started with Drasi",
-  "workspaceFolder": "/workspaces/learning/tutorial/getting-started",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}/tutorial/getting-started",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:dev-22",
   "onCreateCommand": "sed -i 's/\r$//' ../../.devcontainer/post-create.sh && sed -i  's/\r$//' ../../.devcontainer/on-create.sh && bash ../../.devcontainer/on-create.sh",
   "postCreateCommand": "bash ../../.devcontainer/post-create.sh",

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -23,11 +23,13 @@ while ( ! kubectl cluster-info ); do
   sleep 1
 done
 
-## Install Drasi
-sleep 30
-drasi init
-
-# Install PostgreSQL
+echo "Setting up PostgreSQL database with seed data..."
 kubectl apply -f ./resources/drasi-postgres.yaml
 sleep 15
 kubectl wait --for=condition=ready pod -l app=postgres --timeout=60s
+
+echo "Installing Drasi..."
+sleep 30
+drasi init
+
+echo "Setup complete. You can now run your application."

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Copyright 2025 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Function to check if a port is already in use
+check_port() {
+  local port=$1
+  if lsof -i :"$port" > /dev/null 2>&1; then
+    echo "Port $port is already in use. Skipping port-forward."
+    return 1
+  fi
+  return 0
+}
+
+# Set a known log directory
+LOG_DIR="/tmp"
+mkdir -p "$LOG_DIR" || echo "Warning: Could not create $LOG_DIR"
+
+# Clean up any existing port-forward processes
+pkill -f "kubectl port-forward svc/postgres" 2>/dev/null || echo "No prior postgres port-forward process found."
+
+# Verify cluster connectivity
+echo "Checking cluster connectivity..."
+if ! kubectl cluster-info > /dev/null 2>&1; then
+  echo "Error: Cannot connect to the cluster. Check k3d setup."
+  exit 1
+fi
+
+# Verify services exist
+echo "Checking for svc/postgres..."
+kubectl get svc/postgres || echo "Warning: svc/postgres not found."
+
+# Forward PostgreSQL port
+if check_port 5432; then
+  echo "Starting port-forward for PostgreSQL..."
+  nohup kubectl port-forward svc/postgres 5432:5432 > "$LOG_DIR/postgres-port-forward.log" 2>&1 &
+  sleep 1  # Give it a moment to start
+  if ps aux | grep -q "[k]ubectl port-forward svc/postgres"; then
+    echo "PostgreSQL port-forward started (logs at $LOG_DIR/postgres-port-forward.log)."
+  else
+    echo "Error: PostgreSQL port-forward failed to start. Check $LOG_DIR/postgres-port-forward.log."
+  fi
+else
+  echo "PostgreSQL port-forward skipped due to port conflict."
+fi
+
+# Final check
+echo "Running processes:"
+ps aux | grep "[k]ubectl port-forward" || echo "No kubectl port-forward processes found."

--- a/.devcontainer/risky-containers/devcontainer.json
+++ b/.devcontainer/risky-containers/devcontainer.json
@@ -4,7 +4,7 @@
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}/tutorial/risky-containers",
 	"onCreateCommand": "sed -i 's/\r$//' ../../.devcontainer/risky-containers/post-create.sh && sed -i  's/\r$//' ../../.devcontainer/risky-containers/on-create.sh && bash ../../.devcontainer/risky-containers/on-create.sh",
   	"postCreateCommand": "bash ../../.devcontainer/risky-containers/post-create.sh",
-	"postAttachCommand": "nohup bash -c 'kubectl port-forward svc/postgres 5432:5432 &'",
+	"postStartCommand": "bash ../../.devcontainer/curbside-pickup/post-start.sh",
 	"runArgs": [
 	  "--privileged",
 	  "--init"

--- a/.devcontainer/risky-containers/devcontainer.json
+++ b/.devcontainer/risky-containers/devcontainer.json
@@ -4,7 +4,7 @@
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}/tutorial/risky-containers",
 	"onCreateCommand": "sed -i 's/\r$//' ../../.devcontainer/risky-containers/post-create.sh && sed -i  's/\r$//' ../../.devcontainer/risky-containers/on-create.sh && bash ../../.devcontainer/risky-containers/on-create.sh",
   	"postCreateCommand": "bash ../../.devcontainer/risky-containers/post-create.sh",
-	"postStartCommand": "bash ../../.devcontainer/curbside-pickup/post-start.sh",
+	"postStartCommand": "bash ../../.devcontainer/risky-containers/post-start.sh",
 	"runArgs": [
 	  "--privileged",
 	  "--init"

--- a/.devcontainer/risky-containers/post-start.sh
+++ b/.devcontainer/risky-containers/post-start.sh
@@ -29,7 +29,6 @@ mkdir -p "$LOG_DIR" || echo "Warning: Could not create $LOG_DIR"
 
 # Clean up any existing port-forward processes
 pkill -f "kubectl port-forward svc/postgres" 2>/dev/null || echo "No prior postgres port-forward process found."
-pkill -f "kubectl port-forward svc/mysql" 2>/dev/null || echo "No prior mysql port-forward process found."
 
 # Verify cluster connectivity
 echo "Checking cluster connectivity..."
@@ -41,8 +40,6 @@ fi
 # Verify services exist
 echo "Checking for svc/postgres..."
 kubectl get svc/postgres || echo "Warning: svc/postgres not found."
-echo "Checking for svc/mysql..."
-kubectl get svc/mysql || echo "Warning: svc/mysql not found."
 
 # Forward PostgreSQL port
 if check_port 5432; then

--- a/.devcontainer/risky-containers/post-start.sh
+++ b/.devcontainer/risky-containers/post-start.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Copyright 2025 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Function to check if a port is already in use
+check_port() {
+  local port=$1
+  if lsof -i :"$port" > /dev/null 2>&1; then
+    echo "Port $port is already in use. Skipping port-forward."
+    return 1
+  fi
+  return 0
+}
+
+# Set a known log directory
+LOG_DIR="/tmp"
+mkdir -p "$LOG_DIR" || echo "Warning: Could not create $LOG_DIR"
+
+# Clean up any existing port-forward processes
+pkill -f "kubectl port-forward svc/postgres" 2>/dev/null || echo "No prior postgres port-forward process found."
+pkill -f "kubectl port-forward svc/mysql" 2>/dev/null || echo "No prior mysql port-forward process found."
+
+# Verify cluster connectivity
+echo "Checking cluster connectivity..."
+if ! kubectl cluster-info > /dev/null 2>&1; then
+  echo "Error: Cannot connect to the cluster. Check k3d setup."
+  exit 1
+fi
+
+# Verify services exist
+echo "Checking for svc/postgres..."
+kubectl get svc/postgres || echo "Warning: svc/postgres not found."
+echo "Checking for svc/mysql..."
+kubectl get svc/mysql || echo "Warning: svc/mysql not found."
+
+# Forward PostgreSQL port
+if check_port 5432; then
+  echo "Starting port-forward for PostgreSQL..."
+  nohup kubectl port-forward svc/postgres 5432:5432 > "$LOG_DIR/postgres-port-forward.log" 2>&1 &
+  sleep 1  # Give it a moment to start
+  if ps aux | grep -q "[k]ubectl port-forward svc/postgres"; then
+    echo "PostgreSQL port-forward started (logs at $LOG_DIR/postgres-port-forward.log)."
+  else
+    echo "Error: PostgreSQL port-forward failed to start. Check $LOG_DIR/postgres-port-forward.log."
+  fi
+else
+  echo "PostgreSQL port-forward skipped due to port conflict."
+fi
+
+# Final check
+echo "Running processes:"
+ps aux | grep "[k]ubectl port-forward" || echo "No kubectl port-forward processes found."


### PR DESCRIPTION
- Make port-forwarding more robust for codepsaces and devContainers.
- Use workspace folder base name in all codespace configs.