### PR TITLE
Fix scheduled tutorial evaluation failures

### DIFF
--- a/.devcontainer/absence-of-change/devcontainer.json
+++ b/.devcontainer/absence-of-change/devcontainer.json
@@ -42,7 +42,8 @@
     "containerEnv": {
         "LANG": "en_US.UTF-8",
         "LANGUAGE": "en_US:en",
-        "LC_ALL": "en_US.UTF-8"
+        "LC_ALL": "en_US.UTF-8",
+        "DRASI_TUTORIAL_EVALUATION": "${localEnv:DRASI_TUTORIAL_EVALUATION}"
     },
 	"remoteEnv": {
 	  "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",

--- a/.devcontainer/building-comfort/devcontainer.json
+++ b/.devcontainer/building-comfort/devcontainer.json
@@ -29,7 +29,8 @@
   "containerEnv": {
     "LANG": "en_US.UTF-8",
     "LANGUAGE": "en_US:en",
-    "LC_ALL": "en_US.UTF-8"
+    "LC_ALL": "en_US.UTF-8",
+    "DRASI_TUTORIAL_EVALUATION": "${localEnv:DRASI_TUTORIAL_EVALUATION}"
   },
   "remoteEnv": {
     "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",

--- a/.devcontainer/curbside-pickup/devcontainer.json
+++ b/.devcontainer/curbside-pickup/devcontainer.json
@@ -29,7 +29,8 @@
   "containerEnv": {
     "LANG": "en_US.UTF-8",
     "LANGUAGE": "en_US:en",
-    "LC_ALL": "en_US.UTF-8"
+    "LC_ALL": "en_US.UTF-8",
+    "DRASI_TUTORIAL_EVALUATION": "${localEnv:DRASI_TUTORIAL_EVALUATION}"
   },
   "remoteEnv": {
     "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",

--- a/.devcontainer/dapr/devcontainer.json
+++ b/.devcontainer/dapr/devcontainer.json
@@ -34,7 +34,8 @@
   "containerEnv": {
     "LANG": "en_US.UTF-8",
     "LANGUAGE": "en_US:en",
-    "LC_ALL": "en_US.UTF-8"
+    "LC_ALL": "en_US.UTF-8",
+    "DRASI_TUTORIAL_EVALUATION": "${localEnv:DRASI_TUTORIAL_EVALUATION}"
   },
   "remoteEnv": {
     "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,6 +31,9 @@
       ]
     }
   },
+  "containerEnv": {
+    "DRASI_TUTORIAL_EVALUATION": "${localEnv:DRASI_TUTORIAL_EVALUATION}"
+  },
   "remoteEnv": {
     "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
     "GITHUB_ACTIONS": "${localEnv:GITHUB_ACTIONS}",

--- a/.devcontainer/risky-containers/devcontainer.json
+++ b/.devcontainer/risky-containers/devcontainer.json
@@ -42,7 +42,8 @@
     "containerEnv": {
         "LANG": "en_US.UTF-8",
         "LANGUAGE": "en_US:en",
-        "LC_ALL": "en_US.UTF-8"
+        "LC_ALL": "en_US.UTF-8",
+        "DRASI_TUTORIAL_EVALUATION": "${localEnv:DRASI_TUTORIAL_EVALUATION}"
     },
 	"remoteEnv": {
 	  "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",

--- a/.github/prompts/tutorial-evaluation.md
+++ b/.github/prompts/tutorial-evaluation.md
@@ -55,3 +55,8 @@ Constraints:
     - You must not debug failures or Fix anything. Upon hitting any failure, terminate the evaluation immediately and mark it as failed.
     - Do not perform any Drasi or Kubernetes related cleanup steps post completion if mentioned in tutorial docs.
     - Whatever scripts you write or modules you install must remain within the evaluation directory you create at the start of the task.
+
+Final Checklist (complete these before ending):
+    1. Ensure `report.md` exists in the evaluation directory.
+    2. Verify that `report.md` ends with EXACTLY ONE line: `## STATUS: SUCCESS` or `## STATUS: FAILURE`.
+    3. Verify you have NOT written "STATUS: SUCCESS" or "STATUS: FAILURE" anywhere else in the report.

--- a/.github/workflows/tutorial-evaluation-scheduled.yml
+++ b/.github/workflows/tutorial-evaluation-scheduled.yml
@@ -67,7 +67,7 @@ jobs:
           configFile: ${{ matrix.devcontainer }}
           push: never
           runCmd: |
-            copilot -p "$(cat prompt.md)" \
+            timeout 1200 copilot -p "$(cat prompt.md)" \
               --allow-all-tools \
               --allow-all-paths \
               --deny-tool 'fetch' \
@@ -84,9 +84,13 @@ jobs:
               --deny-tool 'shell(dd *)' \
               --allow-url localhost \
               --allow-url 127.0.0.1 \
-              --model gemini-3-pro-preview
+              --model gemini-3-pro-preview || true
+            REPORT=$(find . -name "report.md" -path "*/evaluation-*/*" | sort -r | head -1)
+            if [ -z "$REPORT" ] || ! grep -qiE "^##\s*STATUS:" "$REPORT"; then
+              exit 1
+            fi
 
-      - name: Wait before retry
+      - name: Wait before retry (attempt 2)
         if: steps.attempt1.outcome == 'failure'
         run: |
           echo "Attempt 1 failed. Waiting 60 seconds before retry..."
@@ -94,6 +98,7 @@ jobs:
 
       - name: Run evaluation (attempt 2)
         id: attempt2
+        continue-on-error: true
         if: steps.attempt1.outcome == 'failure'
         uses: devcontainers/ci@v0.3
         env:
@@ -103,7 +108,7 @@ jobs:
           configFile: ${{ matrix.devcontainer }}
           push: never
           runCmd: |
-            copilot -p "$(cat prompt.md)" \
+            timeout 1200 copilot -p "$(cat prompt.md)" \
               --allow-all-tools \
               --allow-all-paths \
               --deny-tool 'fetch' \
@@ -120,12 +125,56 @@ jobs:
               --deny-tool 'shell(dd *)' \
               --allow-url localhost \
               --allow-url 127.0.0.1 \
-              --model gemini-3-pro-preview
+              --model gemini-3-pro-preview || true
+            REPORT=$(find . -name "report.md" -path "*/evaluation-*/*" | sort -r | head -1)
+            if [ -z "$REPORT" ] || ! grep -qiE "^##\s*STATUS:" "$REPORT"; then
+              exit 1
+            fi
+
+      - name: Wait before retry (attempt 3)
+        if: steps.attempt2.outcome == 'failure'
+        run: |
+          echo "Attempt 2 failed. Waiting 60 seconds before retry..."
+          sleep 60
+
+      - name: Run evaluation (attempt 3)
+        id: attempt3
+        if: steps.attempt2.outcome == 'failure'
+        uses: devcontainers/ci@v0.3
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT_TOKEN }}
+          DRASI_TUTORIAL_EVALUATION: "true"
+        with:
+          configFile: ${{ matrix.devcontainer }}
+          push: never
+          runCmd: |
+            timeout 1200 copilot -p "$(cat prompt.md)" \
+              --allow-all-tools \
+              --allow-all-paths \
+              --deny-tool 'fetch' \
+              --deny-tool 'websearch' \
+              --deny-tool 'githubRepo' \
+              --deny-tool 'shell(curl *)' \
+              --deny-tool 'shell(wget *)' \
+              --deny-tool 'shell(nc *)' \
+              --deny-tool 'shell(ssh *)' \
+              --deny-tool 'shell(scp *)' \
+              --deny-tool 'shell(telnet *)' \
+              --deny-tool 'shell(ftp *)' \
+              --deny-tool 'shell(rm -rf /*)' \
+              --deny-tool 'shell(dd *)' \
+              --allow-url localhost \
+              --allow-url 127.0.0.1 \
+              --model claude-opus-4.6 || true
+            REPORT=$(find . -name "report.md" -path "*/evaluation-*/*" | sort -r | head -1)
+            if [ -z "$REPORT" ] || ! grep -qiE "^##\s*STATUS:" "$REPORT"; then
+              exit 1
+            fi
 
       - name: Check evaluation status
         if: always()
         run: |
-          REPORT=$(find ${{ matrix.learning_path }} -name "report.md" -path "*/evaluation-*/*" | head -1)
+          REPORT=$(find ${{ matrix.learning_path }} -name "report.md" -path "*/evaluation-*/*" | sort -r | head -1)
 
           if [ -z "$REPORT" ]; then
             echo "::error::No report.md found in evaluation directory"

--- a/.github/workflows/tutorial-evaluation.yml
+++ b/.github/workflows/tutorial-evaluation.yml
@@ -106,7 +106,7 @@ jobs:
           configFile: ${{ needs.setup.outputs.devcontainer }}
           push: never
           runCmd: |
-            copilot -p "$(cat prompt.md)" \
+            timeout 1200 copilot -p "$(cat prompt.md)" \
               --allow-all-tools \
               --allow-all-paths \
               --deny-tool 'fetch' \
@@ -128,7 +128,7 @@ jobs:
       - name: Check evaluation status
         if: always()
         run: |
-          REPORT=$(find ${{ needs.setup.outputs.learning_path }} -name "report.md" -path "*/evaluation-*/*" | head -1)
+          REPORT=$(find ${{ needs.setup.outputs.learning_path }} -name "report.md" -path "*/evaluation-*/*" | sort -r | head -1)
 
           if [ -z "$REPORT" ]; then
             echo "::error::No report.md found in evaluation directory"


### PR DESCRIPTION
## Summary

The scheduled tutorial evaluation workflow had two categories of failures:

1. **Environment setup failure**: The `DRASI_TUTORIAL_EVALUATION` environment variable was not being passed into the devcontainer, causing the tool installation script to skip installing the Copilot CLI (`command not found` errors).

2. **Non-deterministic LLM failures**: The Copilot CLI agent sometimes produces malformed reports (missing `## STATUS:` line) or no report at all, but exits with code 0 — so the existing retry mechanism never triggered.

## Changes

### Fix: Environment variable propagation
- Added `"DRASI_TUTORIAL_EVALUATION": "${localEnv:DRASI_TUTORIAL_EVALUATION}"` to the `containerEnv` section of all 6 `devcontainer.json` files.

### Fix: Retry mechanism and resilience
- **Timeout**: Added 20-minute timeout on Copilot CLI to prevent runaway token burn.
- **Output validation**: Wrapped copilot invocation with a post-run check that verifies `report.md` exists and contains a valid `## STATUS:` line. If not, the step exits 1, correctly triggering the retry.
- **3rd retry with model escalation**: Added a 3rd retry attempt with model escalation:

  | Attempt | Model | Cost |
  |---------|-------|------|
  | 1 | `gemini-3-pro-preview` | 1x (standard) |
  | 2 | `gemini-3-pro-preview` | 1x (standard) |
  | 3 | `claude-opus-4.6` | 3x (premium) |

  **Rationale**: Attempts 1-2 use the same standard-cost model to handle transient failures cheaply. Attempt 3 escalates to the premium model (`claude-opus-4.6`), which has the strongest agentic instruction-following capabilities — only used when cheaper attempts have already failed.
- **Latest report selection**: Changed `find ... | head -1` to `find ... | sort -r | head -1` so the check step always evaluates the most recent attempt's report, not a stale one from an earlier failed attempt.
- **Prompt reinforcement**: Added a final checklist to the evaluation prompt to reduce report formatting failures.

## Validation
- All 5 tutorials passed with `gemini-3-pro-preview` (5/5 on first attempt)
- All 5 tutorials passed with `claude-opus-4.6` (5/5 on first attempt)

Fixes #70
Fixes #71
Fixes #72