### PR TITLE
Fix broken links in README

### DIFF
--- a/apps/rag-chat-app/README.md
+++ b/apps/rag-chat-app/README.md
@@ -178,7 +178,7 @@ The Chat Application:
 
 ## Resources
 
-- [Drasi Documentation](https://drasi.io/docs)
+- [Drasi Documentation](https://drasi.io/reference)
 - [Semantic Kernel Documentation](https://learn.microsoft.com/semantic-kernel)
 - [Qdrant Documentation](https://qdrant.tech/documentation)
 

--- a/tutorial/absence-of-change/README.md
+++ b/tutorial/absence-of-change/README.md
@@ -1,5 +1,5 @@
 # Getting Started with Drasi
-Follow the tutorial [instructions here](https://drasi.io/tutorials/absence-of-change).
+Follow the tutorial [instructions here](https://drasi.io/drasi-kubernetes/tutorials/absence-of-change).
 
 ### Steps for running in VS Code with a Dev Container
 1. Open this directory in Visual Studio Code

--- a/tutorial/building-comfort/README.md
+++ b/tutorial/building-comfort/README.md
@@ -8,7 +8,7 @@ You'll see Drasi in action in a scenario where:
 - Changes to PostgreSQL are instantly detected by **Drasi**
 - A **Dashboard** displays real-time comfort levels and alerts via SignalR
 
-Follow along the tutorial instructions on [our website here](https://drasi.io/tutorials/building-comfort/).
+Follow along the tutorial instructions on [our website here](https://drasi.io/drasi-kubernetes/tutorials/building-comfort/).
 
 ![Architecture of setup including a control panel for room sensors. Measurements stored in PostgreSQL database, and a realtime dashboard built using Drasi.](images/building-comfort-architecture.png "Building Comfort Tutorial Setup")
 

--- a/tutorial/curbside-pickup/README.md
+++ b/tutorial/curbside-pickup/README.md
@@ -8,7 +8,7 @@ You'll see Drasi in action where:
 - Changes from both systems are observed by **Drasi**
 - **Dashboards** display order readiness and delays in real-time via SignalR
 
-Follow along the tutorial instructions on [our website here](https://drasi.io/tutorials/curbside-pickup/).
+Follow along the tutorial instructions on [our website here](https://drasi.io/drasi-kubernetes/tutorials/curbside-pickup/).
 
 ![Architecture of the setup including a retail-ops app for managing orders in PostgreSQL and physical-ops app for managing vehicles in MySQL. Two realtime dashboards built using Drasi that can detect complex conditions across databases and different services.](images/curbside-pickup-architecture.png "Curbside Pickup Tutorial Setup")
 

--- a/tutorial/dapr/README.md
+++ b/tutorial/dapr/README.md
@@ -10,7 +10,7 @@ You'll see Drasi in action where:
   - **Dashboard**: Real-time monitoring of Gold customer delays and stock issues
   - **Notifications**: Intelligent business events for inventory thresholds
 
-Follow along the tutorial instructions on [our website here](https://drasi.io/drasi-kubernetes/tutorials/dapr/).
+Follow along the tutorial instructions on [our website here](https://drasi.io/drasi-kubernetes/tutorials/drasi-for-dapr/).
 
 ![Architecture of the Dapr + Drasi setup showing four core services, Drasi monitoring, and three Drasi-powered services](images/01-architectire-overview.png "Dapr + Drasi Tutorial Setup")
 

--- a/tutorial/dapr/README.md
+++ b/tutorial/dapr/README.md
@@ -10,7 +10,7 @@ You'll see Drasi in action where:
   - **Dashboard**: Real-time monitoring of Gold customer delays and stock issues
   - **Notifications**: Intelligent business events for inventory thresholds
 
-Follow along the tutorial instructions on [our website here](https://drasi.io/tutorials/dapr/).
+Follow along the tutorial instructions on [our website here](https://drasi.io/drasi-kubernetes/tutorials/dapr/).
 
 ![Architecture of the Dapr + Drasi setup showing four core services, Drasi monitoring, and three Drasi-powered services](images/01-architectire-overview.png "Dapr + Drasi Tutorial Setup")
 

--- a/tutorial/getting-started/02-connect-frontends/README.md
+++ b/tutorial/getting-started/02-connect-frontends/README.md
@@ -1,0 +1,5 @@
+# Connecting a front end app
+
+This tutorial follows on from the [getting started tutorial](https://drasi.io/drasi-kubernetes/getting-started).
+Follow the tutorial [instructions here](https://drasi.io/drasi-kubernetes/tutorials/connecting-frontends).
+

--- a/tutorial/getting-started/02-connect-frontends/react/README.md
+++ b/tutorial/getting-started/02-connect-frontends/react/README.md
@@ -1,0 +1,4 @@
+# Connecting a React App to a Drasi Query
+
+This tutorial follows on from the [getting started tutorial](https://drasi.io/drasi-kubernetes/getting-started).
+Follow the tutorial [instructions here](https://drasi.io/drasi-kubernetes/tutorials/connecting-frontends/react).

--- a/tutorial/getting-started/02-connect-frontends/react/readme.md
+++ b/tutorial/getting-started/02-connect-frontends/react/readme.md
@@ -1,4 +1,0 @@
-# Connecting a React App to a Drasi Query
-
-This tutorial follows on form the [getting started tutorial](https://drasi.io/getting-started).
-Follow the tutorial [instructions here](https://drasi.io/tutorials/connecting-frontends/react).

--- a/tutorial/getting-started/02-connect-frontends/readme.md
+++ b/tutorial/getting-started/02-connect-frontends/readme.md
@@ -1,5 +1,0 @@
-# Connecting a front end app
-
-This tutorial follows on form the [getting started tutorial](https://drasi.io/getting-started).
-Follow the tutorial [instructions here](https://drasi.io/tutorials/connecting-frontends).
-

--- a/tutorial/getting-started/02-connect-frontends/vue/README.md
+++ b/tutorial/getting-started/02-connect-frontends/vue/README.md
@@ -1,4 +1,4 @@
-# Connecting as Vue App to a Drasi Query
+# Connecting a Vue App to a Drasi Query
 
 This tutorial follows on from the [getting started tutorial](https://drasi.io/drasi-kubernetes/getting-started).
 Follow the tutorial [instructions here](https://drasi.io/drasi-kubernetes/tutorials/connecting-frontends/vue).

--- a/tutorial/getting-started/02-connect-frontends/vue/README.md
+++ b/tutorial/getting-started/02-connect-frontends/vue/README.md
@@ -1,4 +1,4 @@
 # Connecting as Vue App to a Drasi Query
 
-This tutorial follows on form the [getting started tutorial](https://drasi.io/getting-started).
-Follow the tutorial [instructions here](https://drasi.io/tutorials/connecting-frontends/vue).
+This tutorial follows on from the [getting started tutorial](https://drasi.io/drasi-kubernetes/getting-started).
+Follow the tutorial [instructions here](https://drasi.io/drasi-kubernetes/tutorials/connecting-frontends/vue).

--- a/tutorial/getting-started/README.md
+++ b/tutorial/getting-started/README.md
@@ -3,14 +3,14 @@
 ### Steps for Github Codespaces
 1. Wait for the setup scripts to finish
 2. Once complete, your codespace will have drasi and all pre-requisites configured.
-3. Follow the tutorial [instructions here](https://drasi.io/getting-started/).
+3. Follow the tutorial [instructions here](https://drasi.io/drasi-kubernetes/getting-started/).
 
 ### Steps for VSCode DevContainer
 1. Open this directory in Visual Studio Code
 2. Open the Command Palette by typing `Ctrl + Shift + P` (windows) or `Cmd + Shift + P` (mac)
 3. Type 'dev containers:'
 4. Select 'Dev Containers: Rebuild and Reopen in Container'
-5. Follow the tutorial [instructions here](https://drasi.io/getting-started/).
+5. Follow the tutorial [instructions here](https://drasi.io/drasi-kubernetes/getting-started/).
 
 ### Alternate: Install Drasi on your own
-1. Follow the tutorial [instructions here](https://drasi.io/getting-started/).
+1. Follow the tutorial [instructions here](https://drasi.io/drasi-kubernetes/getting-started/).

--- a/tutorial/getting-started/README.md
+++ b/tutorial/getting-started/README.md
@@ -1,6 +1,6 @@
 # Getting Started with Drasi
 
-### Steps for Github Codespaces
+### Steps for GitHub Codespaces
 1. Wait for the setup scripts to finish
 2. Once complete, your codespace will have drasi and all pre-requisites configured.
 3. Follow the tutorial [instructions here](https://drasi.io/drasi-kubernetes/getting-started/).

--- a/tutorial/risky-containers/README.md
+++ b/tutorial/risky-containers/README.md
@@ -1,5 +1,5 @@
 # Getting Started with Drasi
-Follow the tutorial [instructions here](https://drasi.io/tutorials/risky-containers).
+Follow the tutorial [instructions here](https://drasi.io/drasi-kubernetes/tutorials/risky-containers).
 
 ### Steps for running in VS Code with a Dev Container
 1. Open this directory in Visual Studio Code


### PR DESCRIPTION
# Description

This PR fixes stale links for tutorials caused by Drasi docs PR #190 and adds some fixes for grammar/file naming conventions.

## Changes
- Update tutorial links to point to Drasi Kubernetes tutorials under `/drasi-kubernetes`
- Update docs links to point to the new documentation under `/reference`
- Rename `readme` to `README` for consistency
- Typo fixes

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now.

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

