### PR TITLE
Fixed the agentic tutorial evaluation workflows

### DIFF
--- a/.devcontainer/absence-of-change/devcontainer.json
+++ b/.devcontainer/absence-of-change/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Absence of Change with Drasi",
-	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
 	"hostRequirements": {
 		"cpus": 4
 	},

--- a/.devcontainer/absence-of-change/devcontainer.json
+++ b/.devcontainer/absence-of-change/devcontainer.json
@@ -27,7 +27,7 @@
 	// Features to add to the dev container. More info: https://containers.dev/features
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
-			"version": "27",
+			"version": "29",
 			"moby": "false"
 		},
 		"ghcr.io/devcontainers/features/node:1": {

--- a/.devcontainer/absence-of-change/on-create.sh
+++ b/.devcontainer/absence-of-change/on-create.sh
@@ -17,9 +17,9 @@
 # Install kubectl
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg # allow unprivileged APT programs to read this keyring
-echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.34/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
 sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list   # helps tools such as command-not-found to work correctly
 sudo apt-get update
 sudo apt-get install -y kubectl

--- a/.devcontainer/building-comfort/devcontainer.json
+++ b/.devcontainer/building-comfort/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Building Comfort with Drasi",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}/tutorial/building-comfort",
   "onCreateCommand": "bash ../../.devcontainer/building-comfort/on-create.sh",
   "postCreateCommand": "bash ../../.devcontainer/building-comfort/post-create.sh",

--- a/.devcontainer/building-comfort/devcontainer.json
+++ b/.devcontainer/building-comfort/devcontainer.json
@@ -19,7 +19,7 @@
   },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "version": "27",
+      "version": "29",
       "moby": "false"
     },
     "ghcr.io/devcontainers/features/node:1": {

--- a/.devcontainer/building-comfort/on-create.sh
+++ b/.devcontainer/building-comfort/on-create.sh
@@ -16,9 +16,9 @@
 # Install kubectl
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.34/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
 sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update
 sudo apt-get install -y kubectl

--- a/.devcontainer/curbside-pickup/devcontainer.json
+++ b/.devcontainer/curbside-pickup/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Curbside Pickup with Drasi",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}/tutorial/curbside-pickup",
   "onCreateCommand": "bash ../../.devcontainer/curbside-pickup/on-create.sh",
   "postCreateCommand": "bash ../../.devcontainer/curbside-pickup/post-create.sh",

--- a/.devcontainer/curbside-pickup/devcontainer.json
+++ b/.devcontainer/curbside-pickup/devcontainer.json
@@ -19,7 +19,7 @@
   },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "version": "27",
+      "version": "29",
       "moby": "false"
     },
     "ghcr.io/devcontainers/features/node:1": {

--- a/.devcontainer/curbside-pickup/on-create.sh
+++ b/.devcontainer/curbside-pickup/on-create.sh
@@ -16,9 +16,9 @@
 # Install kubectl
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.34/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
 sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update
 sudo apt-get install -y kubectl

--- a/.devcontainer/dapr/devcontainer.json
+++ b/.devcontainer/dapr/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Drasi For Dapr",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
   "hostRequirements": {
     "cpus": 8,
     "memory": "16gb",

--- a/.devcontainer/dapr/devcontainer.json
+++ b/.devcontainer/dapr/devcontainer.json
@@ -24,7 +24,7 @@
   },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "version": "27",
+      "version": "29",
       "moby": "false"
     },
     "ghcr.io/devcontainers/features/node:1": {

--- a/.devcontainer/dapr/on-create.sh
+++ b/.devcontainer/dapr/on-create.sh
@@ -16,9 +16,9 @@
 # Install kubectl
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.34/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
 sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update
 sudo apt-get install -y kubectl

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Getting started with Drasi",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}/tutorial/getting-started",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
   "hostRequirements": {
 		"cpus": 4
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
   ],
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "version": "27",
+      "version": "29",
       "moby": "false"
     },
     "ghcr.io/devcontainers/features/node:1": {

--- a/.devcontainer/github-bot/devcontainer.json
+++ b/.devcontainer/github-bot/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "GitHub Bot with Drasi",
-	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}/tutorial/github-bot",
 	"onCreateCommand": "sed -i 's/\r$//' ../../.devcontainer/github-bot/post-create.sh && sed -i  's/\r$//' ../../.devcontainer/github-bot/on-create.sh && bash ../../.devcontainer/github-bot/on-create.sh",
   	"postCreateCommand": "bash ../../.devcontainer/github-bot/post-create.sh",
@@ -21,7 +21,10 @@
 	},
 	// Features to add to the dev container. More info: https://containers.dev/features
 	"features": {
-	  "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+	  "ghcr.io/devcontainers/features/docker-in-docker:2": {
+	    "version": "29",
+	    "moby": "false"
+	  },
 	  "ghcr.io/rio/features/k3d:1": {}
 	},
 	// Configure environment variables

--- a/.devcontainer/github-bot/on-create.sh
+++ b/.devcontainer/github-bot/on-create.sh
@@ -17,9 +17,9 @@
 # Install kubectl
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg # allow unprivileged APT programs to read this keyring
-echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.34/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
 sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list   # helps tools such as command-not-found to work correctly
 sudo apt-get update
 sudo apt-get install -y kubectl

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -17,9 +17,9 @@
 # Install kubectl
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg # allow unprivileged APT programs to read this keyring
-echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.34/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
 sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list   # helps tools such as command-not-found to work correctly
 sudo apt-get update
 sudo apt-get install -y kubectl

--- a/.devcontainer/risky-containers/devcontainer.json
+++ b/.devcontainer/risky-containers/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Risky Containers with Drasi",
-	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
 	"hostRequirements": {
 		"cpus": 4
 	},

--- a/.devcontainer/risky-containers/devcontainer.json
+++ b/.devcontainer/risky-containers/devcontainer.json
@@ -27,7 +27,7 @@
 	// Features to add to the dev container. More info: https://containers.dev/features
 	"features": {
       "ghcr.io/devcontainers/features/docker-in-docker:2": {
-        "version": "27",
+        "version": "29",
         "moby": "false"
       },
 	  "ghcr.io/devcontainers/features/node:1": {

--- a/.devcontainer/risky-containers/on-create.sh
+++ b/.devcontainer/risky-containers/on-create.sh
@@ -17,9 +17,9 @@
 # Install kubectl
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg # allow unprivileged APT programs to read this keyring
-echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.34/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
 sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list   # helps tools such as command-not-found to work correctly
 sudo apt-get update
 sudo apt-get install -y kubectl


### PR DESCRIPTION
# Description

This pull request updates the dev container configurations across multiple environments to use newer base images and feature versions, and upgrades the installation of `kubectl` to use the latest stable release (v1.34). These changes help ensure compatibility with the latest tools and improve the overall security and maintainability of the development environments.

**Base image and feature updates:**
- Updated the `image` field in all `devcontainer.json` files to use `mcr.microsoft.com/devcontainers/base:ubuntu-24.04` instead of the previous default Ubuntu image, ensuring a consistent and up-to-date development base. [[1]](diffhunk://#diff-d17a698865f942145847573df740e1a20f93353f54a3bbfd27f355ced5c94d63L3-R3) [[2]](diffhunk://#diff-bcd980d206f824f5273e572fa065bd7103f8cf2ada6303b1aadd7e0ca028c96dL3-R3) [[3]](diffhunk://#diff-8b0c8983387636972ead1e36194bfad37c72df6922f297726f74df9a4234fe10L3-R3) [[4]](diffhunk://#diff-6cdccfb075d052e8e93bc01c24020930df32a3c050a8d95f0ca1a159f22ae3bbL3-R3) [[5]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L4-R4) [[6]](diffhunk://#diff-536076fc35b7df30e8e2a2daae2f9f35f85f8bd44ccf17b955e3a88ed7eeee3aL3-R3)
- Upgraded the Docker-in-Docker feature version from `27` to `29` in all relevant `devcontainer.json` files for improved Docker compatibility and features. [[1]](diffhunk://#diff-d17a698865f942145847573df740e1a20f93353f54a3bbfd27f355ced5c94d63L30-R30) [[2]](diffhunk://#diff-bcd980d206f824f5273e572fa065bd7103f8cf2ada6303b1aadd7e0ca028c96dL22-R22) [[3]](diffhunk://#diff-8b0c8983387636972ead1e36194bfad37c72df6922f297726f74df9a4234fe10L22-R22) [[4]](diffhunk://#diff-6cdccfb075d052e8e93bc01c24020930df32a3c050a8d95f0ca1a159f22ae3bbL27-R27) [[5]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L18-R18) [[6]](diffhunk://#diff-536076fc35b7df30e8e2a2daae2f9f35f85f8bd44ccf17b955e3a88ed7eeee3aL30-R30)

**kubectl installation updates:**
- Changed the `kubectl` installation process in all `on-create.sh` scripts to use the v1.34 stable repository and GPG key, replacing the previous v1.31 references. This ensures that the latest stable version of `kubectl` is installed in all environments. [[1]](diffhunk://#diff-c1b67f003e84de97aadfa53ff06a3f618791aba68a459917c1ed2b272f0304f9L20-R22) [[2]](diffhunk://#diff-1b78f388565f75bcbc8dfe3746280a28bcc1789fac8c39417a18bf6228c63fd3L19-R21) [[3]](diffhunk://#diff-6884e5d5141e78cd7f30e42708490932e7912e0b511a94b99d06f3dd8464f3bcL20-R22)

No other functional or application logic changes are included.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now.

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #98 
